### PR TITLE
Fix critical handlebars vulnerability by upgrading to 4.7.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
-    "name": "openapi-typescript-codegen",
-    "version": "0.29.0",
+    "name": "@thulium/openapi-typescript-codegen",
+    "version": "0.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "openapi-typescript-codegen",
-            "version": "0.29.0",
+            "name": "@thulium/openapi-typescript-codegen",
+            "version": "0.0.2",
             "license": "MIT",
             "dependencies": {
                 "@apidevtools/json-schema-ref-parser": "^11.5.4",
                 "camelcase": "^6.3.0",
                 "commander": "^12.0.0",
                 "fs-extra": "^11.2.0",
-                "handlebars": "^4.7.8"
+                "handlebars": "^4.7.9"
             },
             "bin": {
                 "openapi": "bin/index.js"
@@ -547,6 +547,7 @@
             "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-17.3.3.tgz",
             "integrity": "sha512-poLW3FHe5wkxmTIsQ3em2vq4obgQHyZJz6biF+4hCqQSNMbMBS0e5ZycAiJLkUD/WLc88lQZ20muRO7qjVuMLA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -596,6 +597,7 @@
             "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.3.3.tgz",
             "integrity": "sha512-GwlKetNpfWKiG2j4S6bYTi6PA2iT4+eln7o8owo44xZWdQnWQjfxnH39vQuCyhi6OOQL1dozmae+fVXgQsV6jQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -632,6 +634,7 @@
             "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.3.3.tgz",
             "integrity": "sha512-vM0lqwuXQZ912HbLnIuvUblvIz2WEUsU7a5Z2ieNey6famH4zxPH12vCbVwXgicB6GLHorhOfcWC5443wD2mJw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/core": "7.23.9",
                 "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -705,6 +708,7 @@
             "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.3.3.tgz",
             "integrity": "sha512-O/jr3aFJMCxF6Jmymjx4jIigRHJfqM/ALIi60y2LVznBVFkk9xyMTsAjgWQIEHX+2muEIzgfKuXzpL0y30y+wA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -739,6 +743,7 @@
             "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.3.3.tgz",
             "integrity": "sha512-XFWjquD+Pr9VszRzrDlT6uaf57TsY9XhL9iHCNok6Op5DpVQpIAuw1vFt2t5ZoQ0gv+lY8mVWnxgqe3CgTdYxw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -921,6 +926,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.9.tgz",
             "integrity": "sha512-5e3FI4Q3M3Pbr21+5xJwCv6ZT6KmGkI0vw3Tozy5ODAQFTIWe37iT8Cr7Ice2Ntb+M3iSKCEWMB1MBgKrW3whg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.24.7",
@@ -5433,18 +5439,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/eslint": {
-            "version": "8.56.7",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.7.tgz",
-            "integrity": "sha512-SjDvI/x3zsZnOkYZ3lCt9lOZWZLB2jIlNKz+LBgCtDurK0JZcwucxYHn1w2BJkD34dgX9Tjnak0txtq4WTggEA==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/estree": "*",
-                "@types/json-schema": "*"
-            }
-        },
         "node_modules/@types/estree": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -5584,6 +5578,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
             "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -5748,6 +5743,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
             "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "7.18.0",
                 "@typescript-eslint/types": "7.18.0",
@@ -6191,6 +6187,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
             "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -6282,6 +6279,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
             "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -7008,6 +7006,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001640",
                 "electron-to-chromium": "^1.4.820",
@@ -7224,6 +7223,7 @@
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
             "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -8220,7 +8220,8 @@
             "version": "0.0.1312386",
             "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
             "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/diff": {
             "version": "4.0.2",
@@ -8617,6 +8618,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
             "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -8672,6 +8674,7 @@
             "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
             "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
             },
@@ -9865,9 +9868,10 @@
             "dev": true
         },
         "node_modules/handlebars": {
-            "version": "4.7.8",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-            "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+            "version": "4.7.9",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+            "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+            "license": "MIT",
             "dependencies": {
                 "minimist": "^1.2.5",
                 "neo-async": "^2.6.2",
@@ -10799,6 +10803,7 @@
             "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
             "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@jest/core": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -12655,6 +12660,7 @@
             "resolved": "https://registry.npmjs.org/less/-/less-4.2.0.tgz",
             "integrity": "sha512-P3b3HJDBtSzsXUl0im2L7gTO5Ubg8mEN6G8qoTS77iXxXX4Hvu4Qj540PZDvQ8V6DmX6iXo98k7Md0Cm1PrLaA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "copy-anything": "^2.0.1",
                 "parse-node-version": "^1.0.1",
@@ -14451,6 +14457,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.7",
                 "picocolors": "^1.0.0",
@@ -14589,6 +14596,7 @@
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
             "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -15283,6 +15291,7 @@
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
             "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.1.0"
             }
@@ -15318,6 +15327,7 @@
             "resolved": "https://registry.npmjs.org/sass/-/sass-1.71.1.tgz",
             "integrity": "sha512-wovtnV2PxzteLlfNzbgm1tFXPLoZILYAMJtvoXXkD7/+1uP41eKkIt1ypWq5/q2uT94qHjXehEYfmjKOvjL9sg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
                 "immutable": "^4.0.0",
@@ -16290,6 +16300,7 @@
             "resolved": "https://registry.npmjs.org/terser/-/terser-5.29.1.tgz",
             "integrity": "sha512-lZQ/fyaIGxsbGxApKmoPTODIzELy3++mXhS5hOqaAWZjQtpq/hFHAc+rm29NND1rYRxRWKcjuARNwULNXa5RtQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
                 "acorn": "^8.8.2",
@@ -16342,6 +16353,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -16593,6 +16605,7 @@
             "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
             "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -16708,6 +16721,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
             "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -16974,6 +16988,7 @@
             "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.7.tgz",
             "integrity": "sha512-sgnEEFTZYMui/sTlH1/XEnVNHMujOahPLGMxn1+5sIT45Xjng1Ec1K78jRP15dSmVgg5WBin9yO81j3o9OxofA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.19.3",
                 "postcss": "^8.4.35",
@@ -17481,6 +17496,7 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
             "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/estree": "^1.0.5",
                 "@webassemblyjs/ast": "^1.12.1",
@@ -17555,6 +17571,7 @@
             "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.1.tgz",
             "integrity": "sha512-5hbAst3h3C3L8w6W4P96L5vaV0PxSmJhxZvWKYIdgxOQm8pNZ5dEOmmSLBVpP85ReeyRt6AS1QJNyo/oFFPeVA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/bonjour": "^3.5.9",
                 "@types/connect-history-api-fallback": "^1.3.5",
@@ -17749,6 +17766,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -18123,7 +18141,8 @@
             "version": "0.14.8",
             "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.14.8.tgz",
             "integrity": "sha512-48uh7MnVp4/OQDuCHeFdXw5d8xwPqFTvlHgPJ1LBFb5GaustLSZV+YUH0to5ygNyGpqTsjpbpt141U/j3pCfqQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@thulium/openapi-typescript-codegen",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "Library that generates Typescript clients based on the OpenAPI specification.",
     "author": "Ferdi Koomen",
     "homepage": "https://github.com/ferdikoomen/openapi-typescript-codegen",
@@ -61,7 +61,7 @@
         "camelcase": "^6.3.0",
         "commander": "^12.0.0",
         "fs-extra": "^11.2.0",
-        "handlebars": "^4.7.8"
+        "handlebars": "^4.7.9"
     },
     "devDependencies": {
         "@angular-devkit/build-angular": "17.3.9",


### PR DESCRIPTION
### Summary

Bumps `handlebars` from `^4.7.8` to `^4.7.9` to address multiple critical security vulnerabilities (JavaScript injection, prototype pollution, XSS). Bumps package version to `0.0.2`.

### Changes

- Update `handlebars` dependency from `^4.7.8` to `^4.7.9`
- Bump package version from `0.0.1` to `0.0.2`